### PR TITLE
perf(prompt-profiles): cache default task profile template and fingerprint

### DIFF
--- a/prompting/prompt-profiles.js
+++ b/prompting/prompt-profiles.js
@@ -825,18 +825,31 @@ function applyRuntimeDefaultTemplateOverrides(taskType, template = null) {
   return template;
 }
 
+// 性能缓存：默认任务模板与指纹只依赖模块级常量（DEFAULT_*_TEMPLATES / FALLBACK_DEFAULT_TASK_BLOCKS / PLANNER_*），
+// 运行时不会变化，因此按 taskType 缓存是安全的，无需失效（页面刷新即重置）。
+// 此前每次调用都全量深拷贝 + JSON.stringify + 逐字符 FNV 哈希，是提取/召回时主线程秒级卡顿的主因。
+// 注意：缓存对象按只读共享，调用方不得修改返回值（现有调用方均为只读）。
+const defaultTaskProfileTemplateCache = new Map();
+const defaultTaskProfileStampCache = new Map();
+
 function getDefaultTaskProfileTemplate(taskType) {
-  if (String(taskType || "") === "planner") {
-    return buildPlannerDefaultTaskProfileTemplate();
+  const cacheKey = String(taskType || "");
+  if (defaultTaskProfileTemplateCache.has(cacheKey)) {
+    return defaultTaskProfileTemplateCache.get(cacheKey);
   }
-  const templateKey = String(taskType || "");
-  const template =
-    DEFAULT_AGENT_TASK_PROFILE_TEMPLATES?.[templateKey] ||
-    DEFAULT_TASK_PROFILE_TEMPLATES?.[templateKey];
-  if (!template || typeof template !== "object") {
-    return null;
+  let template = null;
+  if (cacheKey === "planner") {
+    template = buildPlannerDefaultTaskProfileTemplate();
+  } else {
+    const source =
+      DEFAULT_AGENT_TASK_PROFILE_TEMPLATES?.[cacheKey] ||
+      DEFAULT_TASK_PROFILE_TEMPLATES?.[cacheKey];
+    if (source && typeof source === "object") {
+      template = applyRuntimeDefaultTemplateOverrides(cacheKey, cloneJson(source));
+    }
   }
-  return applyRuntimeDefaultTemplateOverrides(templateKey, cloneJson(template));
+  defaultTaskProfileTemplateCache.set(cacheKey, template);
+  return template;
 }
 
 function hashTemplateFingerprint(value = "") {
@@ -855,8 +868,12 @@ function getDefaultTaskProfileTemplateFingerprint(taskType) {
 }
 
 function getDefaultTaskProfileTemplateStamp(taskType) {
+  const cacheKey = String(taskType || "");
+  if (defaultTaskProfileStampCache.has(cacheKey)) {
+    return defaultTaskProfileStampCache.get(cacheKey);
+  }
   const template = getDefaultTaskProfileTemplate(taskType);
-  return {
+  const stamp = {
     version: Number.isFinite(Number(template?.version))
       ? Number(template.version)
       : DEFAULT_TASK_PROFILE_VERSION,
@@ -866,6 +883,8 @@ function getDefaultTaskProfileTemplateStamp(taskType) {
         : "",
     fingerprint: getDefaultTaskProfileTemplateFingerprint(taskType),
   };
+  defaultTaskProfileStampCache.set(cacheKey, stamp);
+  return stamp;
 }
 
 function buildDefaultTaskBlockTripletsFromTemplate(taskType) {

--- a/tests/prompt-profiles-cache.mjs
+++ b/tests/prompt-profiles-cache.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import {
+  createDefaultTaskProfile,
+  normalizeTaskProfile,
+} from "../prompting/prompt-profiles.js";
+
+// 回归测试：任务模板/指纹按 taskType 缓存后，
+// 重复构建必须返回全新对象且内容一致、指纹稳定。
+const first = createDefaultTaskProfile("extract_objective");
+const second = createDefaultTaskProfile("extract_objective");
+assert.notEqual(first, second);
+assert.deepEqual(second, first);
+assert.equal(
+  first.metadata.defaultTemplateFingerprint,
+  second.metadata.defaultTemplateFingerprint,
+);
+
+// 所有内置任务类型都能构建，且缓存不破坏对象隔离与指纹一致性。
+for (const taskType of [
+  "extract_subjective",
+  "recall",
+  "agent_recall",
+  "compress",
+  "synopsis",
+  "summary_rollup",
+  "reflection",
+  "consolidation",
+  "agent_steward",
+  "planner",
+]) {
+  const a = createDefaultTaskProfile(taskType);
+  const b = createDefaultTaskProfile(taskType);
+  assert.ok(a && Array.isArray(a.blocks) && a.blocks.length > 0, taskType);
+  assert.notEqual(a, b, taskType);
+  assert.deepEqual(b, a, taskType);
+  assert.equal(
+    a.metadata.defaultTemplateFingerprint,
+    b.metadata.defaultTemplateFingerprint,
+    taskType,
+  );
+}
+
+// normalizeTaskProfile 仍然正常合并用户 profile。
+const normalized = normalizeTaskProfile("extract_objective", { version: 3 });
+assert.equal(normalized.taskType, "extract_objective");
+assert.equal(normalized.id, "default");
+assert.ok(Array.isArray(normalized.blocks) && normalized.blocks.length > 0);
+
+console.log("prompt-profiles cache tests passed");


### PR DESCRIPTION
# PR：perf(prompt-profiles) — 缓存默认任务模板与指纹

## 问题

提取 / 召回时 SillyTavern 页面主线程被秒级阻塞（冻结数秒到十几秒，其他标签页正常）。
Chrome Performance Trace（约 790MB）显示热点集中在：

- `prompting/prompt-profiles.js`
  - `getDefaultTaskProfileTemplate` 自耗约 **124s**
  - `getDefaultTaskProfileTemplateStamp` 约 **26s**
  - `hashTemplateFingerprint` 约 **9s**

根因：`getDefaultTaskProfileTemplate` / `getDefaultTaskProfileTemplateStamp`
每次调用都会对完整默认模板做**深拷贝（cloneJson）→ JSON.stringify → 逐字符 FNV 哈希**，
而提取/召回初始化会同时对全部任务类型重复执行，全部跑在主线程上。

## 修复

按 `taskType` 缓存构建后的默认模板与指纹 stamp：

- `getDefaultTaskProfileTemplate`：每个任务类型只完整构建一次，之后直接返回缓存对象；
- `getDefaultTaskProfileTemplateStamp`：指纹只计算一次，之后复用。

## 为什么缓存是安全的（无需失效）

- 模板只依赖模块级常量：`DEFAULT_TASK_PROFILE_TEMPLATES` /
  `DEFAULT_AGENT_TASK_PROFILE_TEMPLATES` / `FALLBACK_DEFAULT_TASK_BLOCKS` /
  `PLANNER_*`，运行时不变；
- `applyRuntimeDefaultTemplateOverrides` 的输入也是模块常量；
- 所有调用方均只读（`createDefaultTaskProfile` 会把结果展开成新对象返回）；
- 页面刷新会重置模块缓存，无跨会话陈旧问题。

## 测试

- 新增 `tests/prompt-profiles-cache.mjs`：断言重复构建返回全新对象、内容一致、指纹稳定，
  覆盖全部内置任务类型；`normalizeTaskProfile` 合并行为不变；
- `node tests/prompt-profiles-cache.mjs` ✅
- `node tests/task-profile-migration.mjs` ✅（既有迁移测试不回归）
- `node scripts/check-syntax.mjs` ✅ 全仓库语法通过

## 实测效果（本地冒烟）

补丁后 `createDefaultTaskProfile` 重复调用平均 **0.07ms/次**，
`normalizeTaskProfile` 平均 **0.014ms/次**（修复前为每次全量深拷贝 + 序列化 + 哈希）。
